### PR TITLE
Fix a few parameter types that were causing JSON decode errors.

### DIFF
--- a/pkg/smartsheet/cell.go
+++ b/pkg/smartsheet/cell.go
@@ -32,7 +32,7 @@ type Cell struct {
 	LinksOutToCells    []CellLink   `json:"linksOutToCells,omitempty"`    //An array of CellLink objects. Zero or more outbound links from this cell to cells in other sheets whose values mirror this cell's value.
 	ObjectValue        *ObjectValue `json:"objectValue,omitempty"`        //Optionally included object representation of the cell's value. Used for updating predecessor cell values or for multi-contact details.
 	OverrideValidation bool         `json:"overrideValidation,omitempty"` //(Admin only) Indicates whether the cell value can contain a value outside of the validation limits (value = true). When using this parameter, you must also set strict to false to bypass value type checking. This property is honored for POST or PUT actions that update rows.
-	Strict             bool         `json:"strict,omitempty"`             //Set to false to enable lenient parsing. Defaults to true. You can specify this attribute in a request, but it is never present in a response. See Cell Value Parsing for more information about using this attribute.
+	Strict             *bool        `json:"strict,omitempty"`             //Set to false to enable lenient parsing. Defaults to true. You can specify this attribute in a request, but it is never present in a response. See Cell Value Parsing for more information about using this attribute.
 	Value              string       `json:"value,omitempty"`              //string number, or Boolean 	A string, a number, or a Boolean value -- depending on the cell type and the data in the cell. Cell values larger than 4000 characters are silently truncated. An empty cell returns no value. See Cell Reference.
 }
 

--- a/pkg/smartsheet/sheet.go
+++ b/pkg/smartsheet/sheet.go
@@ -198,7 +198,7 @@ type Source struct {
 }
 
 type ProjectSettings struct {
-	LengthOfDay    int64    `json:"lengthOfDay"`    // Length of a workday for a project sheet. Valid value must be above or equal to 1 hour, and less than or equal to 24 hours.
+	LengthOfDay    float64  `json:"lengthOfDay"`    // Length of a workday for a project sheet. Valid value must be above or equal to 1 hour, and less than or equal to 24 hours.
 	NonWorkingDays []string `json:"nonWorkingDays"` // Non-working days for a project sheet. The format for the timestamp array must be an array of strings that are valid ISO-8601 dates ('YYYY-MM-DD').
 	WorkingDays    []string `json:"workingDays"`    // Working days of a week for a project sheet. Valid values must be an array of strings of days of the week: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, or SUNDAY
 }

--- a/pkg/smartsheet/sheet.go
+++ b/pkg/smartsheet/sheet.go
@@ -28,7 +28,7 @@ type Sheet struct {
 	AccessLevel                string                `json:"accessLevel"`                //User's permissions on the sheet
 	Attachments                []Attachment          `json:"attachments"`                //Array of Attachment objects. Only returned if the include query string parameter contains Attachments.
 	Columns                    []Column              `json:"columns"`                    // Array of Column objects
-	CreatedAt                  time.Time             `json:"createdAt"`                  // Time that the sheet was created
+	CreatedAt                  string                `json:"createdAt"`                  // Time that the sheet was created
 	CrossSheetReferences       []CrossSheetReference `json:"crossSheetReferences"`       // Array of CrossSheetReference objects. Only returned if the include query string parameter contains crossSheetReferences.
 	DependenciesEnabled        bool                  `json:"dependenciesEnabled"`        //	Indicates whether dependencies are enabled
 	Discussions                []Discussion          `json:"discussions"`                // Array of Discussion objects. Only returned if the include query string parameter contains discussions.
@@ -36,7 +36,7 @@ type Sheet struct {
 	Favorite                   bool                  `json:"favorite"`                   // Returned only if the user has marked this sheet as a favorite in their Home tab (value = true)
 	GanttEnabled               bool                  `json:"ganttEnabled"`               //	Indicates whether "Gantt View" is enabled
 	HasSummaryFields           bool                  `json:"hasSummaryFields"`           //	Indicates whether a sheet summary is present
-	ModifiedAt                 time.Time             `json:"modifiedAt"`                 // Time that the sheet was modified
+	ModifiedAt                 string                `json:"modifiedAt"`                 // Time that the sheet was modified
 	Name                       string                `json:"name"`                       // Sheet name
 	Owner                      string                `json:"owner"`                      // Email address of the sheet owner
 	Permalink                  string                `json:"permalink"`                  // URL that represents a direct link to the sheet in Smartsheet
@@ -198,9 +198,9 @@ type Source struct {
 }
 
 type ProjectSettings struct {
-	LengthOfDay    int64       `json:"lengthOfDay"`    // Length of a workday for a project sheet. Valid value must be above or equal to 1 hour, and less than or equal to 24 hours.
-	NonWorkingDays []time.Time `json:"nonWorkingDays"` // Non-working days for a project sheet. The format for the timestamp array must be an array of strings that are valid ISO-8601 dates ('YYYY-MM-DD').
-	WorkingDays    []string    `json:"workingDays"`    // Working days of a week for a project sheet. Valid values must be an array of strings of days of the week: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, or SUNDAY
+	LengthOfDay    int64    `json:"lengthOfDay"`    // Length of a workday for a project sheet. Valid value must be above or equal to 1 hour, and less than or equal to 24 hours.
+	NonWorkingDays []string `json:"nonWorkingDays"` // Non-working days for a project sheet. The format for the timestamp array must be an array of strings that are valid ISO-8601 dates ('YYYY-MM-DD').
+	WorkingDays    []string `json:"workingDays"`    // Working days of a week for a project sheet. Valid values must be an array of strings of days of the week: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, or SUNDAY
 }
 
 type CrossSheetReference struct {


### PR DESCRIPTION
# Overview

Fixing a few issues with parameter types that caused JSON decode errors.

## time.Time Type

Noticed that the golang time.Time type is not compatible with ISO 8601 formatted timestamps. Was getting the following decode error when loading a smartsheet:

`2022/03/08 13:42:52 could not decode JSON response: parsing time "\"2021-01-01\"" as "\"2006-01-02T15:04:05Z07:00\"": cannot parse "\"" as "T"`

There appear to be some libraries that support this format, but left the type as a string for flexibility. The client can convert the string to whatever custom time type they prefer.

## LengthOfDay

The smartsheet was presenting a floating point value for LengthOfDay, which was resulting in the following decode error:

`2022/03/08 14:20:12 could not decode JSON response: json: cannot unmarshal number 6.0 into Go struct field ProjectSettings.projectSettings.lengthOfDay of type int64`

Changed the type to a float64 to resolve.

## Strict

The Strict parameter in the Cell struct is a boolean type with an omitempty JSON property. If you set this to false, it will be omitted from a request. In order to allow false values to be set, the idiomatic way is to use a boolean pointer instead.