### PR TITLE
support numeric cell values

### DIFF
--- a/pkg/smartsheet/cell.go
+++ b/pkg/smartsheet/cell.go
@@ -33,7 +33,7 @@ type Cell struct {
 	ObjectValue        *ObjectValue `json:"objectValue,omitempty"`        //Optionally included object representation of the cell's value. Used for updating predecessor cell values or for multi-contact details.
 	OverrideValidation bool         `json:"overrideValidation,omitempty"` //(Admin only) Indicates whether the cell value can contain a value outside of the validation limits (value = true). When using this parameter, you must also set strict to false to bypass value type checking. This property is honored for POST or PUT actions that update rows.
 	Strict             *bool        `json:"strict,omitempty"`             //Set to false to enable lenient parsing. Defaults to true. You can specify this attribute in a request, but it is never present in a response. See Cell Value Parsing for more information about using this attribute.
-	Value              string       `json:"value,omitempty"`              //string number, or Boolean 	A string, a number, or a Boolean value -- depending on the cell type and the data in the cell. Cell values larger than 4000 characters are silently truncated. An empty cell returns no value. See Cell Reference.
+	Value              interface{}  `json:"value,omitempty"`              //string number, or Boolean 	A string, a number, or a Boolean value -- depending on the cell type and the data in the cell. Cell values larger than 4000 characters are silently truncated. An empty cell returns no value. See Cell Reference.
 }
 
 type CellHistory struct {


### PR DESCRIPTION
I'm seeing the below error when trying to read numeric values from a sheet.

`cannot unmarshal number into Go struct field Cell.rows.cells.value of type string`

Here's a stripped down example: https://go.dev/play/p/jsu5RP0bBaP

Cells in my example sheet may contain a mix of numeric and string values.

I've tried setting the Cell's `Value` type to `json.Number` but that did not help.  Setting it to `interface{}` seems to do the trick.

Another small test can be done here: https://go.dev/play/p/Au2lLYucBz5